### PR TITLE
Introduced protections against predictable RNG abuse

### DIFF
--- a/BudgetMasterServer/src/main/java/de/deadlocker8/budgetmaster/settings/demo/DemoDataCreator.java
+++ b/BudgetMasterServer/src/main/java/de/deadlocker8/budgetmaster/settings/demo/DemoDataCreator.java
@@ -11,6 +11,7 @@ import de.deadlocker8.budgetmaster.icon.Icon;
 import de.deadlocker8.budgetmaster.icon.IconService;
 import de.deadlocker8.budgetmaster.transactions.Transaction;
 import de.deadlocker8.budgetmaster.transactions.TransactionService;
+import java.security.SecureRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +48,7 @@ public class DemoDataCreator
 		this.accountService = accountService;
 		this.transactionService = transactionService;
 
-		this.random = new Random();
+		this.random = new SecureRandom();
 	}
 
 	public void createDemoData()


### PR DESCRIPTION
This change replaces all new instances of `java.util.Random` with the marginally slower, but much more secure `java.security.SecureRandom`.

We have to work pretty hard to get computers to generate genuinely unguessable random bits. The `java.util.Random` type uses a method of pseudo-random number generation that unfortunately emits fairly predictable numbers.

If the numbers it emits are predictable, then it's obviously not safe to use in cryptographic operations, file name creation, token construction, password generation, and anything else that's related to security. In fact, it may affect security even if it's not directly obvious.

Switching to a more secure version is simple and our changes all look something like this:

```diff
- Random r = new Random();
+ Random r = new java.security.SecureRandom();
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/vulnerabilities/Insecure_Randomness](https://owasp.org/www-community/vulnerabilities/Insecure_Randomness)
  * [https://metebalci.com/blog/everything-about-javas-securerandom/](https://metebalci.com/blog/everything-about-javas-securerandom/)
  * [https://cwe.mitre.org/data/definitions/330.html](https://cwe.mitre.org/data/definitions/330.html)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/secure-random](https://docs.pixee.ai/codemods/java/pixee_java_secure-random)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Czcarroll4%2FBudgetMaster%7C00206f8485a98fc1e540175b7bb5281aee6d8cf1)

<!--{"type":"DRIP","codemod":"pixee:java/secure-random"}-->